### PR TITLE
corrigindo bug de datas e configurando timezone para o padrao BR

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,3 +38,6 @@ links:
 exclude: ['package.json', 'src', 'node_modules']
 
 future: true
+
+# timezone
+timezone: America/Sao_Paulo

--- a/_posts/2019-07-27-codelab-fllutter-2019.md
+++ b/_posts/2019-07-27-codelab-fllutter-2019.md
@@ -12,7 +12,8 @@ categories:
 twitter_text: 'Codelab Flutter na UFABC'
 introduction: 'Vamos realizar este codelab mais uma vez na Universidade Federal do ABC (UFABC). Na unidade de Santo André, que fica no endereço: Av. dos Estados, 5001 · Santo André - A sala desta vez será a S-311-2.'
 ---
- Ola pessoal, tudo bem? Aqui estamos mais uma vez.
+
+Olá pessoal, tudo bem? Aqui estamos mais uma vez.
 
 Sim! Vamos fazer hora extra neste mês de Julho! rs
 
@@ -47,4 +48,4 @@ se organizar com que exatamente levar.
 É isso pessoal!
 Nos vemos no dia 27/07 pessoal! Até lá!
 
- [Clique aqui e confira o Link oficial da conferência](https://www.meetup.com/pt-BR/GDG-ABC/events/262951676/)
+[Clique aqui e confira o Link oficial da conferência](https://www.meetup.com/pt-BR/GDG-ABC/events/262951676/)

--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@ layout: default
     itemtype="http://schema.org/Blog">
     <div id="grid" class="row flex-grid">
 
-        {% capture now %}{{'now' | date: '%s'}}{% endcapture %}
+        {% capture now %}{{'now' | date: '%Y-%m-%d'}}{% endcapture %}
 
         {% assign sorted_posts = site.posts | sort:"date" | reversed %}
         {% for post in sorted_posts %}
 
-        {% capture date %}{{post.date | date: '%s'}}{% endcapture %}
+        {% capture date %}{{post.date | date: '%Y-%m-%d'}}{% endcapture %}
         {% if date >= now %}
         <article class="box-item post-{{post.main-class}}" itemscope="itemscope"
             itemtype="http://schema.org/BlogPosting" itemprop="blogPost">


### PR DESCRIPTION
- Correção de textos e links em um post
- Configuração do timezone default para o horário de Brasilia (sim, SP segue o horário default do Brasil que é Brasília)
- Correção do bug de datas. Anteriormente uma conferência não era exibida no dia em que estivesse ocorrendo. Com o fix, agora ela também será exibida no dia e apenas deixará de aparecer no dia seguinte.