### PR TITLE
#90 add GDG DevFest Rio 2019

### DIFF
--- a/_posts/2019-11-23-devfest-rj-2019.md
+++ b/_posts/2019-11-23-devfest-rj-2019.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: 'DevFest Rio de Janeiro 2019'
+date_from: 2019-11-23
+date_to: 2019-11-23
+description: 'O DevFest é um evento de grande porte criado por e para desenvolvedores e interessados em tecnologia.'
+link: 'https://www.sympla.com.br/devfest-rio-de-janeiro__680060'
+tags:
+- gdg
+- devfest
+- rj
+---
+
+O DevFest é um evento de grande porte criado por e para desenvolvedores e interessados em tecnologia.
+
+Esse evento é organizado pelas comunidades do GDG - Google Developers Group e o WTM - Women Techmakers do Estado do Rio de Janeiro, e acontece em vários locais do mundo!
+
+Neste evento vocês podem contar várias atividades, tais como: Sessões de palestras de diversas Áreas, Minicursos e muito mais.
+
+O DevFest Rio de Janeiro acontece no modelo de outros DevFests ao redor do planeta, mas com características locais e esta é a nossa terceira edição do evento em nossa região.


### PR DESCRIPTION
Adiciona o GDG DevFest Rio de Janeiro 2019 que acontecerá no dia 23 de novembro no Campus da Universidade Estácio no Shopping Nova América. 

Este PR atende a issue #90 